### PR TITLE
With the update to fast-xml-parser you can no longer just use xml.parse().

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,6 +1,6 @@
 const _ = require("lodash");
 const axios = require("axios");
-const xml = require("fast-xml-parser");
+const { XMLParser } = require("fast-xml-parser");
 const { readFileSync } = require("fs-extra");
 const json5 = require("json5");
 const logger = require("@darekkay/logger");
@@ -20,6 +20,7 @@ const getUrlsForSitemap = async (sitemapUrl) => {
     const response = await axios.get(sitemapUrl);
     const sitemap = response.data;
     if (sitemap) {
+      const xml = new XMLParser({ ignoreAttributes: false, });
       const json = xml.parse(sitemap);
       if (json && json.urlset && json.urlset.url) {
         return json.urlset.url.map((url) => url.loc);

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -20,7 +20,7 @@ const getUrlsForSitemap = async (sitemapUrl) => {
     const response = await axios.get(sitemapUrl);
     const sitemap = response.data;
     if (sitemap) {
-      const xml = new XMLParser({ ignoreAttributes: false, });
+      const xml = new XMLParser({ ignoreAttributes: false });
       const json = xml.parse(sitemap);
       if (json && json.urlset && json.urlset.url) {
         return json.urlset.url.map((url) => url.loc);


### PR DESCRIPTION
You now have to create an instance of the XMLParser object from that library.

This fixes that and now allows the sitemap functionality to work again.

Broken example:

```
npx evaluatory --sitemap https://www.foo.com/sitemap.xml -m axe-core,html-validate -o foo-report
Need to install the following packages:
  evaluatory
Ok to proceed? (y)
× xml.parse is not a function
i Adding 0 URLs from the sitemap.
× Error: Specify URLs to evaluate.
    at main (C:\Users\foo\AppData\Local\npm-cache\_npx\40cdadd758bd873b\node_modules\evaluatory\bin\evaluatory.js:39:11)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```